### PR TITLE
Safeguards setting of env var to prevent exception when value is None

### DIFF
--- a/src/helmfile.py
+++ b/src/helmfile.py
@@ -22,6 +22,6 @@ def delete(environment, helmfilePath, purge=False):
 def apply_environ(environment):
     for key, value in environment.items():
         if value is None:
-            print('\nUnable to set env var %s -- value is missing' % (key))
+            raise TypeError('\nUnable to set env var %s -- value is None' % (key))
         else:
             environ[key] = value

--- a/src/helmfile.py
+++ b/src/helmfile.py
@@ -21,4 +21,7 @@ def delete(environment, helmfilePath, purge=False):
 
 def apply_environ(environment):
     for key, value in environment.items():
-        environ[key] = value
+        if value is None:
+            print('\nUnable to set env var %s -- value is missing' % (key))
+        else:
+            environ[key] = value

--- a/src/helmfile.py
+++ b/src/helmfile.py
@@ -22,6 +22,6 @@ def delete(environment, helmfilePath, purge=False):
 def apply_environ(environment):
     for key, value in environment.items():
         if value is None:
-            raise TypeError('\nUnable to set env var %s -- value is None' % (key))
+            raise TypeError('Unable to set env var %s -- value is None' % (key))
         else:
             environ[key] = value


### PR DESCRIPTION
@bastianeicher as it can be quite cumbersome to find out which env var is causing the problem, I suggest to add some output and avoid the exception if value is `None`